### PR TITLE
Fix: update server function validator to inputValidator

### DIFF
--- a/skills/tanstack-start/rules/sf-create-server-fn.md
+++ b/skills/tanstack-start/rules/sf-create-server-fn.md
@@ -45,7 +45,7 @@ const createPostSchema = z.object({
 })
 
 export const createPost = createServerFn({ method: 'POST' })
-  .validator(createPostSchema)
+  .inputValidator(createPostSchema)
   .handler(async ({ data }) => {
     // This code only runs on the server
     const post = await db.posts.create({
@@ -118,7 +118,7 @@ export const Route = createFileRoute('/posts/$postId')({
 ```tsx
 // Compose server functions
 export const getPostWithComments = createServerFn()
-  .validator(z.object({ postId: z.string() }))
+  .inputValidator(z.object({ postId: z.string() }))
   .handler(async ({ data }) => {
     const [post, comments] = await Promise.all([
       getPost({ data: { id: data.postId } }),


### PR DESCRIPTION
Updated all `.validator()` calls in server function examples to `.inputValidator()` to match the official TanStack Start API